### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/pygege-dev/config.json
+++ b/apps/pygege-dev/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "pygege-dev",
-  "tipi_version": 2,
-  "version": "1.3.0",
+  "tipi_version": 3,
+  "version": "1.4.0",
   "categories": ["utilities"],
   "description": "Torznab API for YGG Torrent via Nostr relay",
   "short_desc": "YGG Torznab API",
@@ -25,5 +25,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1772000000000,
-  "updated_at": 1772845004634
+  "updated_at": 1772846252867
 }

--- a/apps/pygege-dev/docker-compose.json
+++ b/apps/pygege-dev/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "pygege-dev",
-      "image": "masutayunikon/pygege:1.3.0",
+      "image": "masutayunikon/pygege:1.4.0",
       "internalPort": 8000,
       "volumes": [
         {

--- a/apps/pygege-dev/docker-compose.yml
+++ b/apps/pygege-dev/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pygege-dev:
-    image: masutayunikon/pygege:1.3.0
+    image: masutayunikon/pygege:1.4.0
     container_name: pygege-dev
     volumes:
       - ${APP_DATA_DIR}/data:/app/data

--- a/apps/pygege/config.json
+++ b/apps/pygege/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "pygege",
-  "tipi_version": 7,
-  "version": "1.3.0",
+  "tipi_version": 8,
+  "version": "1.4.0",
   "categories": ["utilities"],
   "description": "Torznab API for YGG Torrent via Nostr relay",
   "short_desc": "YGG Torznab API",
@@ -25,5 +25,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1772000000000,
-  "updated_at": 1772845004484
+  "updated_at": 1772846252631
 }

--- a/apps/pygege/docker-compose.json
+++ b/apps/pygege/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "pygege",
-      "image": "masutayunikon/pygege:1.3.0",
+      "image": "masutayunikon/pygege:1.4.0",
       "environment": [
         {
           "key": "TMDB_API_KEY",

--- a/apps/pygege/docker-compose.yml
+++ b/apps/pygege/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pygege:
-    image: masutayunikon/pygege:1.3.0
+    image: masutayunikon/pygege:1.4.0
     container_name: pygege
     volumes:
       - ${APP_DATA_DIR}/data:/app/data


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **PyGégé** : `1.3.0` → `1.4.0` · tipi_version `8` · [Release](https://github.com/Masutayunikon/PYGeGe/releases/tag/v1.4.0)
- **PyGégé dev** : `1.3.0` → `1.4.0` · tipi_version `3` · [Release](https://github.com/Masutayunikon/PYGeGe/releases/tag/v1.4.0)