### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/bazarr/config.json
+++ b/apps/bazarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 6767,
   "id": "bazarr",
-  "tipi_version": 21,
-  "version": "1.5.2",
+  "tipi_version": 22,
+  "version": "1.5.6",
   "categories": ["media", "utilities"],
   "description": "Bazarr is a companion application to Sonarr and Radarr that manages and downloads subtitles based on your requirements.",
   "short_desc": "A companion application to Sonarr and Radarr that manages and downloads subtitles",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1748976402869
+  "updated_at": 1772898215035
 }

--- a/apps/bazarr/docker-compose.json
+++ b/apps/bazarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "bazarr",
-      "image": "lscr.io/linuxserver/bazarr:1.5.2",
+      "image": "lscr.io/linuxserver/bazarr:1.5.6",
       "isMain": true,
       "internalPort": 6767,
       "environment": {

--- a/apps/bazarr/docker-compose.yml
+++ b/apps/bazarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   bazarr:
-    image: lscr.io/linuxserver/bazarr:1.5.2
+    image: lscr.io/linuxserver/bazarr:1.5.6
     container_name: bazarr
     environment:
       - PUID=1000

--- a/apps/flaresolverr/config.json
+++ b/apps/flaresolverr/config.json
@@ -7,9 +7,9 @@
   "dynamic_config": true,
   "no_gui": true,
   "id": "flaresolverr",
-  "tipi_version": 25,
+  "tipi_version": 26,
   "min_tipi_version": "3.6.0",
-  "version": "v3.4.0",
+  "version": "v3.4.6",
   "categories": ["media", "security", "utilities"],
   "description": "FlareSolverr is a proxy server to bypass Cloudflare and DDoS-GUARD protection.",
   "short_desc": "Bypass Cloudflare and DDoS-GuARD.",
@@ -19,5 +19,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1756142160174
+  "updated_at": 1772898215340
 }

--- a/apps/flaresolverr/docker-compose.json
+++ b/apps/flaresolverr/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "flaresolverr",
-      "image": "ghcr.io/flaresolverr/flaresolverr:v3.4.0",
+      "image": "ghcr.io/flaresolverr/flaresolverr:v3.4.6",
       "internalPort": 8191,
       "isMain": true,
       "environment": {

--- a/apps/flaresolverr/docker-compose.yml
+++ b/apps/flaresolverr/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   flaresolverr:
     container_name: flaresolverr
-    image: ghcr.io/flaresolverr/flaresolverr:v3.4.0
+    image: ghcr.io/flaresolverr/flaresolverr:v3.4.6
     restart: unless-stopped
     ports:
       - ${APP_PORT}:8191

--- a/apps/jellyfin/config.json
+++ b/apps/jellyfin/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8091,
   "id": "jellyfin",
-  "tipi_version": 28,
-  "version": "10.10.7",
+  "tipi_version": 29,
+  "version": "10.11.6",
   "categories": ["media"],
   "description": "Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps. Jellyfin is descended from Emby's 3.5.2 release and ported to the .NET Core framework to enable full cross-platform support. There are no strings attached, no premium licenses or features, and no hidden agendas: just a team who want to build something better and work together to achieve it. We welcome anyone who is interested in joining us in our quest!",
   "short_desc": "A media server for your home collection",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1743888339000
+  "updated_at": 1772898215632
 }

--- a/apps/jellyfin/docker-compose.json
+++ b/apps/jellyfin/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "jellyfin",
-      "image": "lscr.io/linuxserver/jellyfin:10.10.7",
+      "image": "lscr.io/linuxserver/jellyfin:10.11.6",
       "isMain": true,
       "internalPort": 8096,
       "environment": {

--- a/apps/jellyfin/docker-compose.yml
+++ b/apps/jellyfin/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   jellyfin:
-    image: lscr.io/linuxserver/jellyfin:10.10.7
+    image: lscr.io/linuxserver/jellyfin:10.11.6
     container_name: jellyfin
     volumes:
       - ${APP_DATA_DIR}/data/config:/config

--- a/apps/jellyseerr/config.json
+++ b/apps/jellyseerr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8163,
   "id": "jellyseerr",
-  "tipi_version": 25,
-  "version": "2.7.3",
+  "tipi_version": 26,
+  "version": "3.1.0",
   "categories": ["media", "utilities"],
   "description": "Jellyseerr is a free and open source software application for managing requests for your media library. It is a a fork of Overseerr built to bring support for Jellyfin & Emby media servers!",
   "short_desc": "Fork of overseerr for Jellyfin support",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1755439251205
+  "updated_at": 1772898215981
 }

--- a/apps/jellyseerr/docker-compose.json
+++ b/apps/jellyseerr/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "jellyseerr",
-      "image": "fallenbagel/jellyseerr:2.7.3",
+      "image": "fallenbagel/jellyseerr:3.1.0",
       "isMain": true,
       "internalPort": 5055,
       "environment": {

--- a/apps/jellyseerr/docker-compose.yml
+++ b/apps/jellyseerr/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   jellyseerr:
     container_name: jellyseerr
-    image: fallenbagel/jellyseerr:2.7.3
+    image: fallenbagel/jellyseerr:3.1.0
     ports:
       - ${APP_PORT}:5055
     volumes:

--- a/apps/portfolio/config.json
+++ b/apps/portfolio/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 3000,
   "id": "portfolio",
-  "tipi_version": 35,
-  "version": "latest",
+  "tipi_version": 36,
+  "version": "1.2.0",
   "categories": ["utilities", "development"],
   "description": "Nuxt container to run my portfolio",
   "short_desc": "My portfolio",
@@ -54,5 +54,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1752088173009
+  "updated_at": 1772898216278
 }

--- a/apps/portfolio/docker-compose.json
+++ b/apps/portfolio/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "portfolio",
-      "image": "masutayunikon/portfolio:latest",
+      "image": "masutayunikon/portfolio:1.2.0",
       "environment": {
         "NODE_ENV": "production",
         "NUXT_SMTP_HOST": "${NUXT_SMTP_HOST}",

--- a/apps/portfolio/docker-compose.yml
+++ b/apps/portfolio/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   portfolio:
-    image: masutayunikon/portfolio:latest
+    image: masutayunikon/portfolio:1.2.0
     container_name: portfolio
     restart: unless-stopped
     environment:

--- a/apps/prowlarr/config.json
+++ b/apps/prowlarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8109,
   "id": "prowlarr",
-  "tipi_version": 27,
-  "version": "2.0.5",
+  "tipi_version": 28,
+  "version": "2.3.0",
   "categories": ["media", "utilities"],
   "description": "Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).",
   "short_desc": "A torrent/usenet indexer manager/proxy",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1756170648303
+  "updated_at": 1772898216460
 }

--- a/apps/prowlarr/docker-compose.json
+++ b/apps/prowlarr/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "prowlarr",
-      "image": "ghcr.io/linuxserver/prowlarr:2.0.5",
+      "image": "ghcr.io/linuxserver/prowlarr:2.3.0",
       "isMain": true,
       "internalPort": 9696,
       "environment": {

--- a/apps/prowlarr/docker-compose.yml
+++ b/apps/prowlarr/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   prowlarr:
     container_name: prowlarr
-    image: ghcr.io/linuxserver/prowlarr:2.0.5
+    image: ghcr.io/linuxserver/prowlarr:2.3.0
     environment:
       - TZ=${TZ}
     dns:

--- a/apps/pygege-dev/config.json
+++ b/apps/pygege-dev/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "pygege-dev",
-  "tipi_version": 1,
-  "version": "dev",
+  "tipi_version": 2,
+  "version": "1.4.1",
   "categories": ["utilities"],
   "description": "Torznab API for YGG Torrent via Nostr relay",
   "short_desc": "YGG Torznab API",
@@ -25,5 +25,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1772000000000,
-  "updated_at": 1772000000000
+  "updated_at": 1772898216779
 }

--- a/apps/pygege-dev/docker-compose.json
+++ b/apps/pygege-dev/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "pygege-dev",
-      "image": "masutayunikon/pygege:dev",
+      "image": "masutayunikon/pygege:1.4.1",
       "internalPort": 8000,
       "volumes": [
         {

--- a/apps/pygege-dev/docker-compose.yml
+++ b/apps/pygege-dev/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pygege-dev:
-    image: masutayunikon/pygege:dev
+    image: masutayunikon/pygege:1.4.1
     container_name: pygege-dev
     volumes:
       - ${APP_DATA_DIR}/data:/app/data

--- a/apps/pygege/config.json
+++ b/apps/pygege/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "pygege",
-  "tipi_version": 6,
-  "version": "latest",
+  "tipi_version": 7,
+  "version": "1.4.1",
   "categories": ["utilities"],
   "description": "Torznab API for YGG Torrent via Nostr relay",
   "short_desc": "YGG Torznab API",
@@ -25,5 +25,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1772000000000,
-  "updated_at": 1772000000000
+  "updated_at": 1772898216632
 }

--- a/apps/pygege/docker-compose.json
+++ b/apps/pygege/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "pygege",
-      "image": "masutayunikon/pygege:latest",
+      "image": "masutayunikon/pygege:1.4.1",
       "environment": [
         {
           "key": "TMDB_API_KEY",

--- a/apps/pygege/docker-compose.yml
+++ b/apps/pygege/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pygege:
-    image: masutayunikon/pygege:latest
+    image: masutayunikon/pygege:1.4.1
     container_name: pygege
     volumes:
       - ${APP_DATA_DIR}/data:/app/data

--- a/apps/qbittorrent-nordvpn/config.json
+++ b/apps/qbittorrent-nordvpn/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8153,
   "id": "qbittorrent-nordvpn",
-  "tipi_version": 32,
-  "version": "5.1.2",
+  "tipi_version": 33,
+  "version": "5.1.4",
   "categories": ["utilities"],
   "description": "qBittorrent is a fast, easy, and free BitTorrent client.",
   "short_desc": "Fast, easy, and free BitTorrent client",
@@ -47,5 +47,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1748992181245
+  "updated_at": 1772898217177
 }

--- a/apps/qbittorrent-nordvpn/docker-compose.json
+++ b/apps/qbittorrent-nordvpn/docker-compose.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "qbittorrent-nordvpn",
-      "image": "lscr.io/linuxserver/qbittorrent:5.1.2",
+      "image": "lscr.io/linuxserver/qbittorrent:5.1.4",
       "environment": {
         "PUID": "1000",
         "PGID": "1000",

--- a/apps/qbittorrent-nordvpn/docker-compose.yml
+++ b/apps/qbittorrent-nordvpn/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     labels:
       runtipi.managed: true
   qbittorrent-nordvpn:
-    image: lscr.io/linuxserver/qbittorrent:5.1.2
+    image: lscr.io/linuxserver/qbittorrent:5.1.4
     container_name: qbittorrent-nordvpn
     environment:
       - PUID=1000

--- a/apps/radarr/config.json
+++ b/apps/radarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8088,
   "id": "radarr",
-  "tipi_version": 35,
-  "version": "5.27.5",
+  "tipi_version": 36,
+  "version": "6.0.4",
   "categories": ["media", "utilities"],
   "description": "Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available. Note that only one type of a given movie is supported. If you want both an 4k version and 1080p version of a given movie you will need multiple instances.",
   "short_desc": "Movie collection manager for Usenet and BitTorrent users.",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1752088173009
+  "updated_at": 1772898217359
 }

--- a/apps/radarr/docker-compose.json
+++ b/apps/radarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "radarr",
-      "image": "ghcr.io/linuxserver/radarr:5.27.5",
+      "image": "ghcr.io/linuxserver/radarr:6.0.4",
       "isMain": true,
       "internalPort": 7878,
       "environment": {

--- a/apps/radarr/docker-compose.yml
+++ b/apps/radarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   radarr:
-    image: ghcr.io/linuxserver/radarr:5.27.5
+    image: ghcr.io/linuxserver/radarr:6.0.4
     container_name: radarr
     environment:
       - PUID=1000

--- a/apps/sonarr/config.json
+++ b/apps/sonarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8098,
   "id": "sonarr",
-  "tipi_version": 22,
-  "version": "4.0.15",
+  "tipi_version": 23,
+  "version": "4.0.16",
   "categories": ["media", "utilities"],
   "description": "Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
   "short_desc": "TV show manager for Usenet and BitTorrent",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1752087816251
+  "updated_at": 1772898217667
 }

--- a/apps/sonarr/docker-compose.json
+++ b/apps/sonarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "sonarr",
-      "image": "lscr.io/linuxserver/sonarr:4.0.15",
+      "image": "lscr.io/linuxserver/sonarr:4.0.16",
       "isMain": true,
       "internalPort": 8989,
       "environment": {

--- a/apps/sonarr/docker-compose.yml
+++ b/apps/sonarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   sonarr:
-    image: lscr.io/linuxserver/sonarr:4.0.15
+    image: lscr.io/linuxserver/sonarr:4.0.16
     container_name: sonarr
     environment:
       - PUID=1000

--- a/apps/wizarr/config.json
+++ b/apps/wizarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "wizarr",
-  "tipi_version": 13,
-  "version": "4.2.0",
+  "tipi_version": 14,
+  "version": "2026.2.1",
   "categories": ["utilities"],
   "description": "Wizarr is an automatic user invitation system for Plex and Jellyfin. Create a unique link and share it to a user and they will be invited to your Media Server after they complete there signup proccess! They can even be guided to download the clients and read instructions on how to use your media software!",
   "short_desc": "Wizarr is an automatic user invitation system for Plex and Jellyfin.",
@@ -17,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734288343000
+  "updated_at": 1772898217836
 }

--- a/apps/wizarr/docker-compose.json
+++ b/apps/wizarr/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "wizarr",
-      "image": "ghcr.io/wizarrrr/wizarr:4.2.0",
+      "image": "ghcr.io/wizarrrr/wizarr:2026.2.1",
       "isMain": true,
       "internalPort": 5690,
       "volumes": [

--- a/apps/wizarr/docker-compose.yml
+++ b/apps/wizarr/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   wizarr:
     container_name: wizarr
-    image: ghcr.io/wizarrrr/wizarr:4.2.0
+    image: ghcr.io/wizarrrr/wizarr:2026.2.1
     ports:
       - ${APP_PORT}:5690
     volumes:

--- a/apps/ygege/config.json
+++ b/apps/ygege/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "ygege",
-  "tipi_version": 5,
-  "version": "1.0.0",
+  "tipi_version": 6,
+  "version": "0.8.0",
   "categories": ["utilities"],
   "description": "Ygg",
   "short_desc": "ygg api",
@@ -36,5 +36,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1734288343000
+  "updated_at": 1772898218023
 }

--- a/apps/ygege/docker-compose.json
+++ b/apps/ygege/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "ygege",
-      "image": "masutayunikon/ygege:1.0.0",
+      "image": "masutayunikon/ygege:0.8.0",
       "environment": [
         {
           "key": "FLARESOLVERR_URL",

--- a/apps/ygege/docker-compose.yml
+++ b/apps/ygege/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   ygege:
-    image: masutayunikon/ygege:1.0.0
+    image: masutayunikon/ygege:0.8.0
     container_name: ygege
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Bazarr** : `1.5.2` → `1.5.6` · tipi_version `22` · [Release](https://github.com/morpheus65535/bazarr/releases/tag/v1.5.6)
- **Flaresolverr** : `v3.4.0` → `v3.4.6` · tipi_version `26` · [Release](https://github.com/FlareSolverr/FlareSolverr/releases/tag/v3.4.6)
- **Jellyfin** : `10.10.7` → `10.11.6` · tipi_version `29` · [Release](https://github.com/jellyfin/jellyfin/releases/tag/v10.11.6)
- **Jellyseerr** : `2.7.3` → `3.1.0` · tipi_version `26` · [Release](https://github.com/seerr-team/seerr/releases/tag/v3.1.0)
- **Portfolio** : `latest` → `1.2.0` · tipi_version `36` · [Release](https://github.com/Masutayunikon/Portfolio-w7/releases/tag/v1.2.0)
- **Prowlarr** : `2.0.5` → `2.3.0` · tipi_version `28` · [Release](https://github.com/Prowlarr/Prowlarr/releases/tag/v2.3.0.5236)
- **PyGégé** : `latest` → `1.4.1` · tipi_version `7` · [Release](https://github.com/Masutayunikon/PYGeGe/releases/tag/v1.4.1)
- **PyGégé dev** : `dev` → `1.4.1` · tipi_version `2` · [Release](https://github.com/Masutayunikon/PYGeGe/releases/tag/v1.4.1)
- **qBittorrent Nordvpn** : `5.1.2` → `5.1.4` · tipi_version `33` · [Release](https://github.com/qbittorrent/qBittorrent/releases/tag/release-5.1.4)
- **Radarr** : `5.27.5` → `6.0.4` · tipi_version `36` · [Release](https://github.com/Radarr/Radarr/releases/tag/v6.0.4.10291)
- **Sonarr** : `4.0.15` → `4.0.16` · tipi_version `23` · [Release](https://github.com/Sonarr/Sonarr/releases/tag/v4.0.16.2944)
- **Wizarr** : `4.2.0` → `2026.2.1` · tipi_version `14` · [Release](https://github.com/wizarrrr/wizarr/releases/tag/v2026.2.1)
- **Ygégé API** : `1.0.0` → `0.8.0` · tipi_version `6` · [Release](https://github.com/UwUDev/ygege/releases/tag/v0.8.0)