### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/ygege/config.json
+++ b/apps/ygege/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "ygege",
-  "tipi_version": 6,
-  "version": "0.8.0",
+  "tipi_version": 7,
+  "version": "0.9.0",
   "categories": ["utilities"],
   "description": "Ygg",
   "short_desc": "ygg api",
@@ -36,5 +36,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1772898302223
+  "updated_at": 1772964172237
 }

--- a/apps/ygege/docker-compose.json
+++ b/apps/ygege/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "ygege",
-      "image": "masutayunikon/ygege:0.8.0",
+      "image": "masutayunikon/ygege:0.9.0",
       "environment": [
         {
           "key": "FLARESOLVERR_URL",

--- a/apps/ygege/docker-compose.yml
+++ b/apps/ygege/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   ygege:
-    image: masutayunikon/ygege:0.8.0
+    image: masutayunikon/ygege:0.9.0
     container_name: ygege
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Ygégé API** : `0.8.0` → `0.9.0` · tipi_version `7` · [Release](https://github.com/UwUDev/ygege/releases/tag/v0.9.0)