### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/fankarr/config.json
+++ b/apps/fankarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fankarr",
-  "tipi_version": 2,
-  "version": "1.2.0",
+  "tipi_version": 3,
+  "version": "1.3.0",
   "categories": [
     "media"
   ],
@@ -30,5 +30,5 @@
     "amd64"
   ],
   "created_at": 1772000000000,
-  "updated_at": 1772898300264
+  "updated_at": 1773235585565
 }

--- a/apps/fankarr/docker-compose.json
+++ b/apps/fankarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fankarr",
-      "image": "masutayunikon/fankarr:1.2.0",
+      "image": "masutayunikon/fankarr:1.3.0",
       "environment": [
         {
           "key": "PUID",

--- a/apps/fankarr/docker-compose.yml
+++ b/apps/fankarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   fankarr:
-    image: masutayunikon/fankarr:1.2.0
+    image: masutayunikon/fankarr:1.3.0
     container_name: fankarr
     environment:
       - PUID=1000


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Fankarr** : `1.2.0` → `1.3.0` · tipi_version `3` · [Release](https://github.com/Masutayunikon/FanKarr/releases/tag/v1.3.0)