### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/fankarr/config.json
+++ b/apps/fankarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fankarr",
-  "tipi_version": 6,
-  "version": "1.6.0",
+  "tipi_version": 7,
+  "version": "1.7.1",
   "categories": [
     "media"
   ],
@@ -30,5 +30,5 @@
     "amd64"
   ],
   "created_at": 1772000000000,
-  "updated_at": 1773240764537
+  "updated_at": 1773354437494
 }

--- a/apps/fankarr/docker-compose.json
+++ b/apps/fankarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fankarr",
-      "image": "masutayunikon/fankarr:1.6.0",
+      "image": "masutayunikon/fankarr:1.7.1",
       "environment": [
         {
           "key": "PUID",

--- a/apps/fankarr/docker-compose.yml
+++ b/apps/fankarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   fankarr:
-    image: masutayunikon/fankarr:1.6.0
+    image: masutayunikon/fankarr:1.7.1
     container_name: fankarr
     environment:
       - PUID=1000

--- a/apps/ygege/config.json
+++ b/apps/ygege/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "ygege",
-  "tipi_version": 7,
-  "version": "0.9.0",
+  "tipi_version": 8,
+  "version": "0.9.1",
   "categories": ["utilities"],
   "description": "Ygg",
   "short_desc": "ygg api",
@@ -36,5 +36,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1772964172237
+  "updated_at": 1773354439463
 }

--- a/apps/ygege/docker-compose.json
+++ b/apps/ygege/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "ygege",
-      "image": "masutayunikon/ygege:0.9.0",
+      "image": "masutayunikon/ygege:0.9.1",
       "environment": [
         {
           "key": "FLARESOLVERR_URL",

--- a/apps/ygege/docker-compose.yml
+++ b/apps/ygege/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   ygege:
-    image: masutayunikon/ygege:0.9.0
+    image: masutayunikon/ygege:0.9.1
     container_name: ygege
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Fankarr** : `1.6.0` → `1.7.1` · tipi_version `7` · [Release](https://github.com/Masutayunikon/FanKarr/releases/tag/v1.7.1)
- **Ygégé API** : `0.9.0` → `0.9.1` · tipi_version `8` · [Release](https://github.com/UwUDev/ygege/releases/tag/v0.9.1)