### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/fankarr/config.json
+++ b/apps/fankarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fankarr",
-  "tipi_version": 15,
-  "version": "1.11.1",
+  "tipi_version": 16,
+  "version": "1.11.3",
   "categories": [
     "media"
   ],
@@ -30,5 +30,5 @@
     "amd64"
   ],
   "created_at": 1772000000000,
-  "updated_at": 1773446371888
+  "updated_at": 1774020656105
 }

--- a/apps/fankarr/docker-compose.json
+++ b/apps/fankarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fankarr",
-      "image": "masutayunikon/fankarr:1.11.1",
+      "image": "masutayunikon/fankarr:1.11.3",
       "environment": [
         {
           "key": "PUID",

--- a/apps/fankarr/docker-compose.yml
+++ b/apps/fankarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   fankarr:
-    image: masutayunikon/fankarr:1.11.1
+    image: masutayunikon/fankarr:1.11.3
     container_name: fankarr
     environment:
       - PUID=1000

--- a/apps/sonarr/config.json
+++ b/apps/sonarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8098,
   "id": "sonarr",
-  "tipi_version": 23,
-  "version": "4.0.16",
+  "tipi_version": 24,
+  "version": "4.0.17",
   "categories": ["media", "utilities"],
   "description": "Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
   "short_desc": "TV show manager for Usenet and BitTorrent",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1772898301601
+  "updated_at": 1774020658501
 }

--- a/apps/sonarr/docker-compose.json
+++ b/apps/sonarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "sonarr",
-      "image": "lscr.io/linuxserver/sonarr:4.0.16",
+      "image": "lscr.io/linuxserver/sonarr:4.0.17",
       "isMain": true,
       "internalPort": 8989,
       "environment": {

--- a/apps/sonarr/docker-compose.yml
+++ b/apps/sonarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   sonarr:
-    image: lscr.io/linuxserver/sonarr:4.0.16
+    image: lscr.io/linuxserver/sonarr:4.0.17
     container_name: sonarr
     environment:
       - PUID=1000


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Fankarr** : `1.11.1` → `1.11.3` · tipi_version `16` · [Release](https://github.com/Masutayunikon/FanKarr/releases/tag/v1.11.3)
- **Sonarr** : `4.0.16` → `4.0.17` · tipi_version `24` · [Release](https://github.com/Sonarr/Sonarr/releases/tag/v4.0.17.2952)