### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/fankarr/config.json
+++ b/apps/fankarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fankarr",
-  "tipi_version": 38,
-  "version": "3.1.1",
+  "tipi_version": 39,
+  "version": "3.3.3",
   "categories": [
     "media"
   ],
@@ -30,5 +30,5 @@
     "amd64"
   ],
   "created_at": 1772000000000,
-  "updated_at": 1774691137227
+  "updated_at": 1775651037471
 }

--- a/apps/fankarr/docker-compose.json
+++ b/apps/fankarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fankarr",
-      "image": "masutayunikon/fankarr:3.1.1",
+      "image": "masutayunikon/fankarr:3.3.3",
       "environment": [
         {
           "key": "PUID",

--- a/apps/fankarr/docker-compose.yml
+++ b/apps/fankarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   fankarr:
-    image: masutayunikon/fankarr:3.1.1
+    image: masutayunikon/fankarr:3.3.3
     container_name: fankarr
     environment:
       - PUID=1000

--- a/apps/jellyfin/config.json
+++ b/apps/jellyfin/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8091,
   "id": "jellyfin",
-  "tipi_version": 28,
-  "version": "10.11.6",
+  "tipi_version": 29,
+  "version": "10.11.8",
   "categories": ["media"],
   "description": "Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps. Jellyfin is descended from Emby's 3.5.2 release and ported to the .NET Core framework to enable full cross-platform support. There are no strings attached, no premium licenses or features, and no hidden agendas: just a team who want to build something better and work together to achieve it. We welcome anyone who is interested in joining us in our quest!",
   "short_desc": "A media server for your home collection",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1772898298674
+  "updated_at": 1775651037849
 }

--- a/apps/jellyfin/docker-compose.json
+++ b/apps/jellyfin/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "jellyfin",
-      "image": "lscr.io/linuxserver/jellyfin:10.11.6",
+      "image": "lscr.io/linuxserver/jellyfin:10.11.8",
       "isMain": true,
       "internalPort": 8096,
       "environment": {

--- a/apps/jellyfin/docker-compose.yml
+++ b/apps/jellyfin/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   jellyfin:
-    image: lscr.io/linuxserver/jellyfin:10.11.6
+    image: lscr.io/linuxserver/jellyfin:10.11.8
     container_name: jellyfin
     volumes:
       - ${APP_DATA_DIR}/data/config:/config

--- a/apps/prowlarr/config.json
+++ b/apps/prowlarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8109,
   "id": "prowlarr",
-  "tipi_version": 28,
-  "version": "2.3.0",
+  "tipi_version": 29,
+  "version": "2.3.5",
   "categories": ["media", "utilities"],
   "description": "Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).",
   "short_desc": "A torrent/usenet indexer manager/proxy",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1772898299696
+  "updated_at": 1775651038217
 }

--- a/apps/prowlarr/docker-compose.json
+++ b/apps/prowlarr/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "prowlarr",
-      "image": "ghcr.io/linuxserver/prowlarr:2.3.0",
+      "image": "ghcr.io/linuxserver/prowlarr:2.3.5",
       "isMain": true,
       "internalPort": 9696,
       "environment": {

--- a/apps/prowlarr/docker-compose.yml
+++ b/apps/prowlarr/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   prowlarr:
     container_name: prowlarr
-    image: ghcr.io/linuxserver/prowlarr:2.3.0
+    image: ghcr.io/linuxserver/prowlarr:2.3.5
     environment:
       - TZ=${TZ}
     dns:

--- a/apps/wizarr/config.json
+++ b/apps/wizarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "wizarr",
-  "tipi_version": 14,
-  "version": "v2026.2.1",
+  "tipi_version": 15,
+  "version": "v2026.4.0",
   "categories": ["utilities"],
   "description": "Wizarr is an automatic user invitation system for Plex and Jellyfin. Create a unique link and share it to a user and they will be invited to your Media Server after they complete there signup proccess! They can even be guided to download the clients and read instructions on how to use your media software!",
   "short_desc": "Wizarr is an automatic user invitation system for Plex and Jellyfin.",
@@ -17,5 +17,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1772898301915
+  "updated_at": 1775651039485
 }

--- a/apps/wizarr/docker-compose.json
+++ b/apps/wizarr/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "wizarr",
-      "image": "ghcr.io/wizarrrr/wizarr:v2026.2.1",
+      "image": "ghcr.io/wizarrrr/wizarr:v2026.4.0",
       "isMain": true,
       "internalPort": 5690,
       "volumes": [

--- a/apps/wizarr/docker-compose.yml
+++ b/apps/wizarr/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   wizarr:
     container_name: wizarr
-    image: ghcr.io/wizarrrr/wizarr:v2026.2.1
+    image: ghcr.io/wizarrrr/wizarr:v2026.4.0
     ports:
       - ${APP_PORT}:5690
     volumes:


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Fankarr** : `3.1.1` → `3.3.3` · tipi_version `39` · [Release](https://github.com/Masutayunikon/FanKarr/releases/tag/v3.3.3)
- **Jellyfin** : `10.11.6` → `10.11.8` · tipi_version `29` · [Release](https://github.com/jellyfin/jellyfin/releases/tag/v10.11.8)
- **Prowlarr** : `2.3.0` → `2.3.5` · tipi_version `29` · [Release](https://github.com/Prowlarr/Prowlarr/releases/tag/v2.3.5.5327)
- **Wizarr** : `v2026.2.1` → `v2026.4.0` · tipi_version `15` · [Release](https://github.com/wizarrrr/wizarr/releases/tag/v2026.4.0)