### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/datacenter-game-server/config.json
+++ b/apps/datacenter-game-server/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": false,
   "id": "datacenter-game-server",
-  "tipi_version": 1,
-  "version": "2.0.1",
+  "tipi_version": 2,
+  "version": "2.0.2",
   "tag_prefix": "datacenter-game-server-v",
   "categories": ["gaming"],
   "description": "DataCenter Tycoon RTS — Multiplayer Game Server",
@@ -67,5 +67,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1744326000000,
-  "updated_at": 1744326000000
+  "updated_at": 1775937637458
 }

--- a/apps/datacenter-game-server/docker-compose.json
+++ b/apps/datacenter-game-server/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "datacenter-game-server",
-      "image": "ghcr.io/masutayunikon/datacenter-game-server:2.0.1",
+      "image": "ghcr.io/masutayunikon/datacenter-game-server:2.0.2",
       "environment": [
         {
           "key": "SERVER_NAME",

--- a/apps/datacenter-game-server/docker-compose.yml
+++ b/apps/datacenter-game-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   datacenter-game-server:
-    image: ghcr.io/masutayunikon/datacenter-game-server:2.0.1
+    image: ghcr.io/masutayunikon/datacenter-game-server:2.0.2
     container_name: datacenter-game-server
     restart: unless-stopped
     ports:

--- a/apps/datacenter-site/config.json
+++ b/apps/datacenter-site/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": false,
   "id": "datacenter-site",
-  "tipi_version": 1,
-  "version": "2.0.2",
+  "tipi_version": 2,
+  "version": "2.0.3",
   "tag_prefix": "datacenter-site-v",
   "categories": ["gaming"],
   "description": "DataCenter Tycoon RTS — Multiplayer browser game",
@@ -18,5 +18,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1744326000000,
-  "updated_at": 1744326000000
+  "updated_at": 1775937637597
 }

--- a/apps/datacenter-site/docker-compose.json
+++ b/apps/datacenter-site/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "datacenter-site",
-      "image": "ghcr.io/masutayunikon/datacenter-site:2.0.2",
+      "image": "ghcr.io/masutayunikon/datacenter-site:2.0.3",
       "internalPort": 4000,
       "isMain": true,
       "extraLabels": {

--- a/apps/datacenter-site/docker-compose.yml
+++ b/apps/datacenter-site/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   datacenter-site:
-    image: ghcr.io/masutayunikon/datacenter-site:2.0.2
+    image: ghcr.io/masutayunikon/datacenter-site:2.0.3
     container_name: datacenter-site
     restart: unless-stopped
     ports:

--- a/apps/fankarr/config.json
+++ b/apps/fankarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fankarr",
-  "tipi_version": 41,
-  "version": "3.7.1",
+  "tipi_version": 42,
+  "version": "3.8.1",
   "categories": [
     "media"
   ],
@@ -30,5 +30,5 @@
     "amd64"
   ],
   "created_at": 1772000000000,
-  "updated_at": 1775906743224
+  "updated_at": 1775937637723
 }

--- a/apps/fankarr/docker-compose.json
+++ b/apps/fankarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fankarr",
-      "image": "masutayunikon/fankarr:3.7.1",
+      "image": "masutayunikon/fankarr:3.8.1",
       "environment": [
         {
           "key": "PUID",

--- a/apps/fankarr/docker-compose.yml
+++ b/apps/fankarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   fankarr:
-    image: masutayunikon/fankarr:3.7.1
+    image: masutayunikon/fankarr:3.8.1
     container_name: fankarr
     environment:
       - PUID=1000


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **DataCenter Tycoon Server** : `2.0.1` → `2.0.2` · tipi_version `2` · [Release](https://github.com/Masutayunikon/DataCenter-Management-Tycoon/releases/tag/datacenter-game-server-v2.0.2)
- **DataCenter Tycoon** : `2.0.2` → `2.0.3` · tipi_version `2` · [Release](https://github.com/Masutayunikon/DataCenter-Management-Tycoon/releases/tag/datacenter-site-v2.0.3)
- **Fankarr** : `3.7.1` → `3.8.1` · tipi_version `42` · [Release](https://github.com/Masutayunikon/FanKarr/releases/tag/v3.8.1)