### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/datacenter-game-server/config.json
+++ b/apps/datacenter-game-server/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": false,
   "id": "datacenter-game-server",
-  "tipi_version": 3,
-  "version": "2.1.0",
+  "tipi_version": 4,
+  "version": "2.1.1",
   "tag_prefix": "datacenter-game-server-v",
   "categories": ["gaming"],
   "description": "DataCenter Tycoon RTS — Multiplayer Game Server",
@@ -67,5 +67,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1744326000000,
-  "updated_at": 1775938263358
+  "updated_at": 1775938615169
 }

--- a/apps/datacenter-game-server/docker-compose.json
+++ b/apps/datacenter-game-server/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "datacenter-game-server",
-      "image": "ghcr.io/masutayunikon/datacenter-game-server:2.1.0",
+      "image": "ghcr.io/masutayunikon/datacenter-game-server:2.1.1",
       "environment": [
         {
           "key": "SERVER_NAME",

--- a/apps/datacenter-game-server/docker-compose.yml
+++ b/apps/datacenter-game-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   datacenter-game-server:
-    image: ghcr.io/masutayunikon/datacenter-game-server:2.1.0
+    image: ghcr.io/masutayunikon/datacenter-game-server:2.1.1
     container_name: datacenter-game-server
     restart: unless-stopped
     ports:

--- a/apps/datacenter-site/config.json
+++ b/apps/datacenter-site/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": false,
   "id": "datacenter-site",
-  "tipi_version": 3,
-  "version": "2.1.0",
+  "tipi_version": 4,
+  "version": "2.1.1",
   "tag_prefix": "datacenter-site-v",
   "categories": ["gaming"],
   "description": "DataCenter Tycoon RTS — Multiplayer browser game",
@@ -18,5 +18,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1744326000000,
-  "updated_at": 1775938263542
+  "updated_at": 1775938615353
 }

--- a/apps/datacenter-site/docker-compose.json
+++ b/apps/datacenter-site/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "datacenter-site",
-      "image": "ghcr.io/masutayunikon/datacenter-site:2.1.0",
+      "image": "ghcr.io/masutayunikon/datacenter-site:2.1.1",
       "internalPort": 4000,
       "isMain": true,
       "extraLabels": {

--- a/apps/datacenter-site/docker-compose.yml
+++ b/apps/datacenter-site/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   datacenter-site:
-    image: ghcr.io/masutayunikon/datacenter-site:2.1.0
+    image: ghcr.io/masutayunikon/datacenter-site:2.1.1
     container_name: datacenter-site
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **DataCenter Tycoon Server** : `2.1.0` → `2.1.1` · tipi_version `4` · [Release](https://github.com/Masutayunikon/DataCenter-Management-Tycoon/releases/tag/datacenter-game-server-v2.1.1)
- **DataCenter Tycoon** : `2.1.0` → `2.1.1` · tipi_version `4` · [Release](https://github.com/Masutayunikon/DataCenter-Management-Tycoon/releases/tag/datacenter-site-v2.1.1)