### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/datacenter-game-server/config.json
+++ b/apps/datacenter-game-server/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": false,
   "id": "datacenter-game-server",
-  "tipi_version": 9,
-  "version": "4.0.0",
+  "tipi_version": 10,
+  "version": "4.0.1",
   "tag_prefix": "datacenter-game-server-v",
   "categories": ["gaming"],
   "description": "DataCenter Tycoon RTS — Multiplayer Game Server",
@@ -67,5 +67,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1744326000000,
-  "updated_at": 1776412852908
+  "updated_at": 1776583422805
 }

--- a/apps/datacenter-game-server/docker-compose.json
+++ b/apps/datacenter-game-server/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "datacenter-game-server",
-      "image": "ghcr.io/masutayunikon/datacenter-game-server:4.0.0",
+      "image": "ghcr.io/masutayunikon/datacenter-game-server:4.0.1",
       "environment": [
         {
           "key": "SERVER_NAME",

--- a/apps/datacenter-game-server/docker-compose.yml
+++ b/apps/datacenter-game-server/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   datacenter-game-server:
-    image: ghcr.io/masutayunikon/datacenter-game-server:4.0.0
+    image: ghcr.io/masutayunikon/datacenter-game-server:4.0.1
     container_name: datacenter-game-server
     restart: unless-stopped
     ports:

--- a/apps/datacenter-site/config.json
+++ b/apps/datacenter-site/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": false,
   "id": "datacenter-site",
-  "tipi_version": 9,
-  "version": "2.4.0",
+  "tipi_version": 10,
+  "version": "2.4.1",
   "tag_prefix": "datacenter-site-v",
   "categories": ["gaming"],
   "description": "DataCenter Tycoon RTS — Multiplayer browser game",
@@ -18,5 +18,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1744326000000,
-  "updated_at": 1776412853169
+  "updated_at": 1776583423157
 }

--- a/apps/datacenter-site/docker-compose.json
+++ b/apps/datacenter-site/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "datacenter-site",
-      "image": "ghcr.io/masutayunikon/datacenter-site:2.4.0",
+      "image": "ghcr.io/masutayunikon/datacenter-site:2.4.1",
       "internalPort": 4000,
       "isMain": true,
       "extraLabels": {

--- a/apps/datacenter-site/docker-compose.yml
+++ b/apps/datacenter-site/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   datacenter-site:
-    image: ghcr.io/masutayunikon/datacenter-site:2.4.0
+    image: ghcr.io/masutayunikon/datacenter-site:2.4.1
     container_name: datacenter-site
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **DataCenter Tycoon Server** : `4.0.0` → `4.0.1` · tipi_version `10` · [Release](https://github.com/Masutayunikon/DataCenter-Management-Tycoon/releases/tag/datacenter-game-server-v4.0.1)
- **DataCenter Tycoon** : `2.4.0` → `2.4.1` · tipi_version `10` · [Release](https://github.com/Masutayunikon/DataCenter-Management-Tycoon/releases/tag/datacenter-site-v2.4.1)