### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/fankarr/config.json
+++ b/apps/fankarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fankarr",
-  "tipi_version": 49,
-  "version": "3.13.2",
+  "tipi_version": 50,
+  "version": "3.14.0",
   "categories": [
     "media"
   ],
@@ -30,5 +30,5 @@
     "amd64"
   ],
   "created_at": 1772000000000,
-  "updated_at": 1778108944652
+  "updated_at": 1778197107538
 }

--- a/apps/fankarr/docker-compose.json
+++ b/apps/fankarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fankarr",
-      "image": "masutayunikon/fankarr:3.13.2",
+      "image": "masutayunikon/fankarr:3.14.0",
       "environment": [
         {
           "key": "PUID",

--- a/apps/fankarr/docker-compose.yml
+++ b/apps/fankarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   fankarr:
-    image: masutayunikon/fankarr:3.13.2
+    image: masutayunikon/fankarr:3.14.0
     container_name: fankarr
     environment:
       - PUID=1000


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Fankarr** : `3.13.2` → `3.14.0` · tipi_version `50` · [Release](https://github.com/Masutayunikon/FanKarr/releases/tag/v3.14.0)