### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/fankarr/config.json
+++ b/apps/fankarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fankarr",
-  "tipi_version": 54,
-  "version": "3.16.0",
+  "tipi_version": 55,
+  "version": "3.17.0",
   "categories": [
     "media"
   ],
@@ -30,5 +30,5 @@
     "amd64"
   ],
   "created_at": 1772000000000,
-  "updated_at": 1778525496860
+  "updated_at": 1779559536605
 }

--- a/apps/fankarr/docker-compose.json
+++ b/apps/fankarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fankarr",
-      "image": "masutayunikon/fankarr:3.16.0",
+      "image": "masutayunikon/fankarr:3.17.0",
       "environment": [
         {
           "key": "PUID",

--- a/apps/fankarr/docker-compose.yml
+++ b/apps/fankarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   fankarr:
-    image: masutayunikon/fankarr:3.16.0
+    image: masutayunikon/fankarr:3.17.0
     container_name: fankarr
     environment:
       - PUID=1000

--- a/apps/jellyfin/config.json
+++ b/apps/jellyfin/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8091,
   "id": "jellyfin",
-  "tipi_version": 29,
-  "version": "10.11.8",
+  "tipi_version": 30,
+  "version": "10.11.9",
   "categories": ["media"],
   "description": "Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps. Jellyfin is descended from Emby's 3.5.2 release and ported to the .NET Core framework to enable full cross-platform support. There are no strings attached, no premium licenses or features, and no hidden agendas: just a team who want to build something better and work together to achieve it. We welcome anyone who is interested in joining us in our quest!",
   "short_desc": "A media server for your home collection",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1775651037849
+  "updated_at": 1779559537017
 }

--- a/apps/jellyfin/docker-compose.json
+++ b/apps/jellyfin/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "jellyfin",
-      "image": "lscr.io/linuxserver/jellyfin:10.11.8",
+      "image": "lscr.io/linuxserver/jellyfin:10.11.9",
       "isMain": true,
       "internalPort": 8096,
       "environment": {

--- a/apps/jellyfin/docker-compose.yml
+++ b/apps/jellyfin/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   jellyfin:
-    image: lscr.io/linuxserver/jellyfin:10.11.8
+    image: lscr.io/linuxserver/jellyfin:10.11.9
     container_name: jellyfin
     volumes:
       - ${APP_DATA_DIR}/data/config:/config

--- a/apps/stalwart-mail/config.json
+++ b/apps/stalwart-mail/config.json
@@ -4,8 +4,8 @@
   "available": true,
   "exposable": true,
   "dynamic_config": true,
-  "tipi_version": 29,
-  "version": "0.13.3",
+  "tipi_version": 30,
+  "version": "0.16.6",
   "port": 8677,
   "id": "stalwart-mail",
   "categories": ["media", "network", "utilities"],
@@ -24,5 +24,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1748546155827
+  "updated_at": 1779559538534
 }

--- a/apps/stalwart-mail/docker-compose.json
+++ b/apps/stalwart-mail/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "stalwart",
-      "image": "stalwartlabs/stalwart:v0.13.3",
+      "image": "stalwartlabs/stalwart:v0.16.6",
       "isMain": true,
       "internalPort": 8080,
       "addPorts": [

--- a/apps/stalwart-mail/docker-compose.yml
+++ b/apps/stalwart-mail/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stalwart-mail:
-    image: stalwartlabs/stalwart:v0.13.3
+    image: stalwartlabs/stalwart:v0.16.6
     container_name: stalwart-mail
     volumes:
       - ${APP_DATA_DIR}/data:/opt/stalwart


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Fankarr** : `3.16.0` → `3.17.0` · tipi_version `55` · [Release](https://github.com/Masutayunikon/FanKarr/releases/tag/v3.17.0)
- **Jellyfin** : `10.11.8` → `10.11.9` · tipi_version `30` · [Release](https://github.com/jellyfin/jellyfin/releases/tag/v10.11.9)
- **Stalwart Mail** : `0.13.3` → `0.16.6` · tipi_version `30` · [Release](https://github.com/stalwartlabs/stalwart/releases/tag/v0.16.6)