### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/fankarr/config.json
+++ b/apps/fankarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fankarr",
-  "tipi_version": 56,
-  "version": "3.18.0",
+  "tipi_version": 57,
+  "version": "3.20.2",
   "categories": [
     "media"
   ],
@@ -30,5 +30,5 @@
     "amd64"
   ],
   "created_at": 1772000000000,
-  "updated_at": 1779789631726
+  "updated_at": 1782478588517
 }

--- a/apps/fankarr/docker-compose.json
+++ b/apps/fankarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fankarr",
-      "image": "masutayunikon/fankarr:3.18.0",
+      "image": "masutayunikon/fankarr:3.20.2",
       "environment": [
         {
           "key": "PUID",

--- a/apps/fankarr/docker-compose.yml
+++ b/apps/fankarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   fankarr:
-    image: masutayunikon/fankarr:3.18.0
+    image: masutayunikon/fankarr:3.20.2
     container_name: fankarr
     environment:
       - PUID=1000

--- a/apps/flaresolverr/config.json
+++ b/apps/flaresolverr/config.json
@@ -7,9 +7,9 @@
   "dynamic_config": true,
   "no_gui": true,
   "id": "flaresolverr",
-  "tipi_version": 26,
+  "tipi_version": 27,
   "min_tipi_version": "3.6.0",
-  "version": "v3.4.6",
+  "version": "v3.5.0",
   "categories": ["media", "security", "utilities"],
   "description": "FlareSolverr is a proxy server to bypass Cloudflare and DDoS-GUARD protection.",
   "short_desc": "Bypass Cloudflare and DDoS-GuARD.",
@@ -19,5 +19,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1772898298381
+  "updated_at": 1782478588691
 }

--- a/apps/flaresolverr/docker-compose.json
+++ b/apps/flaresolverr/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "flaresolverr",
-      "image": "ghcr.io/flaresolverr/flaresolverr:v3.4.6",
+      "image": "ghcr.io/flaresolverr/flaresolverr:v3.5.0",
       "internalPort": 8191,
       "isMain": true,
       "environment": {

--- a/apps/flaresolverr/docker-compose.yml
+++ b/apps/flaresolverr/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   flaresolverr:
     container_name: flaresolverr
-    image: ghcr.io/flaresolverr/flaresolverr:v3.4.6
+    image: ghcr.io/flaresolverr/flaresolverr:v3.5.0
     restart: unless-stopped
     ports:
       - ${APP_PORT}:8191

--- a/apps/jellyfin/config.json
+++ b/apps/jellyfin/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8091,
   "id": "jellyfin",
-  "tipi_version": 31,
-  "version": "10.11.10",
+  "tipi_version": 32,
+  "version": "10.11.11",
   "categories": ["media"],
   "description": "Jellyfin is a Free Software Media System that puts you in control of managing and streaming your media. It is an alternative to the proprietary Emby and Plex, to provide media from a dedicated server to end-user devices via multiple apps. Jellyfin is descended from Emby's 3.5.2 release and ported to the .NET Core framework to enable full cross-platform support. There are no strings attached, no premium licenses or features, and no hidden agendas: just a team who want to build something better and work together to achieve it. We welcome anyone who is interested in joining us in our quest!",
   "short_desc": "A media server for your home collection",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1779789632436
+  "updated_at": 1782478588862
 }

--- a/apps/jellyfin/docker-compose.json
+++ b/apps/jellyfin/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "jellyfin",
-      "image": "lscr.io/linuxserver/jellyfin:10.11.10",
+      "image": "lscr.io/linuxserver/jellyfin:10.11.11",
       "isMain": true,
       "internalPort": 8096,
       "environment": {

--- a/apps/jellyfin/docker-compose.yml
+++ b/apps/jellyfin/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   jellyfin:
-    image: lscr.io/linuxserver/jellyfin:10.11.10
+    image: lscr.io/linuxserver/jellyfin:10.11.11
     container_name: jellyfin
     volumes:
       - ${APP_DATA_DIR}/data/config:/config

--- a/apps/prowlarr/config.json
+++ b/apps/prowlarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8109,
   "id": "prowlarr",
-  "tipi_version": 29,
-  "version": "2.3.5",
+  "tipi_version": 30,
+  "version": "2.4.0",
   "categories": ["media", "utilities"],
   "description": "Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs base stack to integrate with your various PVR apps. Prowlarr supports management of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr, Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers with no per app Indexer setup required (we do it all).",
   "short_desc": "A torrent/usenet indexer manager/proxy",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1775651038217
+  "updated_at": 1782478589317
 }

--- a/apps/prowlarr/docker-compose.json
+++ b/apps/prowlarr/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "prowlarr",
-      "image": "ghcr.io/linuxserver/prowlarr:2.3.5",
+      "image": "ghcr.io/linuxserver/prowlarr:2.4.0",
       "isMain": true,
       "internalPort": 9696,
       "environment": {

--- a/apps/prowlarr/docker-compose.yml
+++ b/apps/prowlarr/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   prowlarr:
     container_name: prowlarr
-    image: ghcr.io/linuxserver/prowlarr:2.3.5
+    image: ghcr.io/linuxserver/prowlarr:2.4.0
     environment:
       - TZ=${TZ}
     dns:

--- a/apps/qbittorrent-nordvpn/config.json
+++ b/apps/qbittorrent-nordvpn/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8153,
   "id": "qbittorrent-nordvpn",
-  "tipi_version": 35,
-  "version": "5.2.1",
+  "tipi_version": 36,
+  "version": "5.2.2",
   "categories": ["utilities"],
   "description": "qBittorrent is a fast, easy, and free BitTorrent client.",
   "short_desc": "Fast, easy, and free BitTorrent client",
@@ -47,5 +47,5 @@
     }
   ],
   "created_at": 1691943801422,
-  "updated_at": 1779789633691
+  "updated_at": 1782478589663
 }

--- a/apps/qbittorrent-nordvpn/docker-compose.json
+++ b/apps/qbittorrent-nordvpn/docker-compose.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "qbittorrent-nordvpn",
-      "image": "lscr.io/linuxserver/qbittorrent:5.2.1",
+      "image": "lscr.io/linuxserver/qbittorrent:5.2.2",
       "environment": {
         "PUID": "1000",
         "PGID": "1000",

--- a/apps/qbittorrent-nordvpn/docker-compose.yml
+++ b/apps/qbittorrent-nordvpn/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     labels:
       runtipi.managed: true
   qbittorrent-nordvpn:
-    image: lscr.io/linuxserver/qbittorrent:5.2.1
+    image: lscr.io/linuxserver/qbittorrent:5.2.2
     container_name: qbittorrent-nordvpn
     environment:
       - PUID=1000

--- a/apps/radarr/config.json
+++ b/apps/radarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8088,
   "id": "radarr",
-  "tipi_version": 37,
-  "version": "6.1.1",
+  "tipi_version": 38,
+  "version": "6.2.1",
   "categories": ["media", "utilities"],
   "description": "Radarr is a movie collection manager for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new movies and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available. Note that only one type of a given movie is supported. If you want both an 4k version and 1080p version of a given movie you will need multiple instances.",
   "short_desc": "Movie collection manager for Usenet and BitTorrent users.",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1774591684758
+  "updated_at": 1782478589845
 }

--- a/apps/radarr/docker-compose.json
+++ b/apps/radarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "radarr",
-      "image": "ghcr.io/linuxserver/radarr:6.1.1",
+      "image": "ghcr.io/linuxserver/radarr:6.2.1",
       "isMain": true,
       "internalPort": 7878,
       "environment": {

--- a/apps/radarr/docker-compose.yml
+++ b/apps/radarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   radarr:
-    image: ghcr.io/linuxserver/radarr:6.1.1
+    image: ghcr.io/linuxserver/radarr:6.2.1
     container_name: radarr
     environment:
       - PUID=1000

--- a/apps/sonarr/config.json
+++ b/apps/sonarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8098,
   "id": "sonarr",
-  "tipi_version": 24,
-  "version": "4.0.17",
+  "tipi_version": 25,
+  "version": "4.0.18",
   "categories": ["media", "utilities"],
   "description": "Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
   "short_desc": "TV show manager for Usenet and BitTorrent",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1774020658501
+  "updated_at": 1782478590115
 }

--- a/apps/sonarr/docker-compose.json
+++ b/apps/sonarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "sonarr",
-      "image": "lscr.io/linuxserver/sonarr:4.0.17",
+      "image": "lscr.io/linuxserver/sonarr:4.0.18",
       "isMain": true,
       "internalPort": 8989,
       "environment": {

--- a/apps/sonarr/docker-compose.yml
+++ b/apps/sonarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   sonarr:
-    image: lscr.io/linuxserver/sonarr:4.0.17
+    image: lscr.io/linuxserver/sonarr:4.0.18
     container_name: sonarr
     environment:
       - PUID=1000

--- a/apps/stalwart-mail/config.json
+++ b/apps/stalwart-mail/config.json
@@ -4,8 +4,8 @@
   "available": true,
   "exposable": true,
   "dynamic_config": true,
-  "tipi_version": 30,
-  "version": "0.16.6",
+  "tipi_version": 31,
+  "version": "0.16.11",
   "port": 8677,
   "id": "stalwart-mail",
   "categories": ["media", "network", "utilities"],
@@ -24,5 +24,5 @@
   ],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1779559538534
+  "updated_at": 1782478590318
 }

--- a/apps/stalwart-mail/docker-compose.json
+++ b/apps/stalwart-mail/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "stalwart",
-      "image": "stalwartlabs/stalwart:v0.16.6",
+      "image": "stalwartlabs/stalwart:v0.16.11",
       "isMain": true,
       "internalPort": 8080,
       "addPorts": [

--- a/apps/stalwart-mail/docker-compose.yml
+++ b/apps/stalwart-mail/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   stalwart-mail:
-    image: stalwartlabs/stalwart:v0.16.6
+    image: stalwartlabs/stalwart:v0.16.11
     container_name: stalwart-mail
     volumes:
       - ${APP_DATA_DIR}/data:/opt/stalwart


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Fankarr** : `3.18.0` → `3.20.2` · tipi_version `57` · [Release](https://github.com/Masutayunikon/FanKarr/releases/tag/v3.20.2)
- **Flaresolverr** : `v3.4.6` → `v3.5.0` · tipi_version `27` · [Release](https://github.com/FlareSolverr/FlareSolverr/releases/tag/v3.5.0)
- **Jellyfin** : `10.11.10` → `10.11.11` · tipi_version `32` · [Release](https://github.com/jellyfin/jellyfin/releases/tag/v10.11.11)
- **Prowlarr** : `2.3.5` → `2.4.0` · tipi_version `30` · [Release](https://github.com/Prowlarr/Prowlarr/releases/tag/v2.4.0.5397)
- **qBittorrent Nordvpn** : `5.2.1` → `5.2.2` · tipi_version `36` · [Release](https://github.com/qbittorrent/qBittorrent/releases/tag/release-5.2.2)
- **Radarr** : `6.1.1` → `6.2.1` · tipi_version `38` · [Release](https://github.com/Radarr/Radarr/releases/tag/v6.2.1.10461)
- **Sonarr** : `4.0.17` → `4.0.18` · tipi_version `25` · [Release](https://github.com/Sonarr/Sonarr/releases/tag/v4.0.18.2971)
- **Stalwart Mail** : `0.16.6` → `0.16.11` · tipi_version `31` · [Release](https://github.com/stalwartlabs/stalwart/releases/tag/v0.16.11)