### PR TITLE
chore: auto-update app versions

### DIFF
--- a/apps/fankarr/config.json
+++ b/apps/fankarr/config.json
@@ -6,8 +6,8 @@
   "exposable": true,
   "dynamic_config": true,
   "id": "fankarr",
-  "tipi_version": 58,
-  "version": "3.20.3",
+  "tipi_version": 59,
+  "version": "3.21.0",
   "categories": [
     "media"
   ],
@@ -30,5 +30,5 @@
     "amd64"
   ],
   "created_at": 1772000000000,
-  "updated_at": 1782480394458
+  "updated_at": 1782642781616
 }

--- a/apps/fankarr/docker-compose.json
+++ b/apps/fankarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fankarr",
-      "image": "masutayunikon/fankarr:3.20.3",
+      "image": "masutayunikon/fankarr:3.21.0",
       "environment": [
         {
           "key": "PUID",

--- a/apps/fankarr/docker-compose.yml
+++ b/apps/fankarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   fankarr:
-    image: masutayunikon/fankarr:3.20.3
+    image: masutayunikon/fankarr:3.21.0
     container_name: fankarr
     environment:
       - PUID=1000

--- a/apps/sonarr/config.json
+++ b/apps/sonarr/config.json
@@ -6,8 +6,8 @@
   "dynamic_config": true,
   "port": 8098,
   "id": "sonarr",
-  "tipi_version": 25,
-  "version": "4.0.18",
+  "tipi_version": 26,
+  "version": "4.0.19",
   "categories": ["media", "utilities"],
   "description": "Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.",
   "short_desc": "TV show manager for Usenet and BitTorrent",
@@ -16,5 +16,5 @@
   "form_fields": [],
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1691943801422,
-  "updated_at": 1782478590115
+  "updated_at": 1782642784186
 }

--- a/apps/sonarr/docker-compose.json
+++ b/apps/sonarr/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "sonarr",
-      "image": "lscr.io/linuxserver/sonarr:4.0.18",
+      "image": "lscr.io/linuxserver/sonarr:4.0.19",
       "isMain": true,
       "internalPort": 8989,
       "environment": {

--- a/apps/sonarr/docker-compose.yml
+++ b/apps/sonarr/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   sonarr:
-    image: lscr.io/linuxserver/sonarr:4.0.18
+    image: lscr.io/linuxserver/sonarr:4.0.19
     container_name: sonarr
     environment:
       - PUID=1000


### PR DESCRIPTION
## 🚀 Apps mises à jour

- **Fankarr** : `3.20.3` → `3.21.0` · tipi_version `59` · [Release](https://github.com/Masutayunikon/FanKarr/releases/tag/v3.21.0)
- **Sonarr** : `4.0.18` → `4.0.19` · tipi_version `26` · [Release](https://github.com/Sonarr/Sonarr/releases/tag/v4.0.19.2979)